### PR TITLE
Allow change of bundle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,26 @@
-build/*
+# OS X
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# Bundler
+.bundle
+
+# Project
 docs/*

--- a/Source/Localize.swift
+++ b/Source/Localize.swift
@@ -121,6 +121,11 @@ public class Localize: NSObject {
         self.provider.update(fileName: fileName)
     }
     
+    /// Update the bundle used to load files from.
+    public func update(bundle: Bundle) {
+        self.provider.update(bundle: bundle)
+    }
+
     /// Update default language
     public func update(defaultLanguage: Languages) {
         self.provider.update(defaultLanguage: defaultLanguage)

--- a/Source/LocalizeCommonProtocol.swift
+++ b/Source/LocalizeCommonProtocol.swift
@@ -13,6 +13,10 @@ class LocalizeCommonProtocol: NSObject {
     /// The rule for name is fileName-LanguageKey.json
     public var fileName = "lang"
 
+    /// Bundle used to load files from.
+    /// Defaults to the main bundle.
+    public var usedBundle: Bundle = Bundle.main
+
     /// Use this for testing mode, search resources in different bundles.
     var testing: Bool = false
     
@@ -54,7 +58,7 @@ class LocalizeCommonProtocol: NSObject {
         if self.testing {
             return Bundle(for: type(of: self))
         }
-        return Bundle.main
+        return usedBundle
     }
     
     
@@ -122,6 +126,11 @@ class LocalizeCommonProtocol: NSObject {
         self.fileName = fileName
     }
     
+    /// Update the bundle used to load files from.
+    public func update(bundle: Bundle) {
+        self.usedBundle = bundle
+    }
+
     // MARK: Localize methods.
     
     

--- a/Source/LocalizeProtocol.swift
+++ b/Source/LocalizeProtocol.swift
@@ -70,6 +70,9 @@ protocol LocalizeProtocol {
     /// Update base file name, searched in path.
     func update(fileName:String)
     
+    /// Update the bundle used to load files from.
+    func update(bundle: Bundle)
+    
     /// Update default language
     func update(defaultLanguage: Languages)
     

--- a/Source/LocalizeStatic.swift
+++ b/Source/LocalizeStatic.swift
@@ -71,6 +71,11 @@ extension Localize {
         return Localize.shared.update(fileName: fileName)
     }
     
+    /// Update the bundle used to load files from.
+    public static func update(bundle: Bundle) {
+        return Localize.shared.update(bundle: bundle)
+    }
+
     /// Update default language
     public static func update(defaultLanguage: Languages) {
         return Localize.shared.update(defaultLanguage: defaultLanguage)


### PR DESCRIPTION
Hi!
I'm currently working on a pod which contains stuff to localize.
The localization shall be bundled with the pod.

Unfortunately, all the localization ends up in the pod's own bundle, not in `Bundle.main`.

Xcode can't cope with translating pods properly, so your library comes to the rescue! It's all I need, except one thing missing: To change the bundle.

Please review the changes - I would be very happy, if you could merge them!

Thanks,

Benjamin